### PR TITLE
修复套件证书更新失败

### DIFF
--- a/cert-up.sh
+++ b/cert-up.sh
@@ -6,6 +6,7 @@ BASE_ROOT=$(cd "$(dirname "$0")";pwd)
 DATE_TIME=`date +%Y%m%d%H%M%S`
 # base crt path
 CRT_BASE_PATH="/usr/syno/etc/certificate"
+PKG_CRT_BASE_PATH="/usr/local/etc/certificate"
 #CRT_BASE_PATH="/Users/carl/Downloads/certificate"
 ACME_BIN_PATH=${BASE_ROOT}/acme.sh
 TEMP_PATH=${BASE_ROOT}/temp
@@ -17,6 +18,7 @@ backupCrt () {
   BACKUP_PATH=${BASE_ROOT}/backup/${DATE_TIME}
   mkdir -p ${BACKUP_PATH}
   cp -r ${CRT_BASE_PATH} ${BACKUP_PATH}
+  cp -r ${PKG_CRT_BASE_PATH} ${BACKUP_PATH}/package_cert
   echo ${BACKUP_PATH} > ${BASE_ROOT}/backup/latest
   echo 'done backupCrt'
   return 0
@@ -58,7 +60,7 @@ generateCrt () {
   else
     echo '[ERR] fail to generateCrt'
     echo "begin revert"
-    revertCrt $2
+    revertCrt
     exit 1;
   fi
 }
@@ -91,8 +93,10 @@ revertCrt () {
     echo "[ERR] backup path: ${BACKUP_PATH} not found."
     return 1
   fi
-  echo "${BACKUP_PATH} ${CRT_BASE_PATH}"
+  echo "${BACKUP_PATH}/certificate ${CRT_BASE_PATH}"
   cp -rf ${BACKUP_PATH}/certificate/* ${CRT_BASE_PATH}
+  echo "${BACKUP_PATH}/package_cert ${PKG_CRT_BASE_PATH}"
+  cp -rf ${BACKUP_PATH}/package_cert/* ${PKG_CRT_BASE_PATH}
   reloadWebService
   echo 'done revertCrt'
 }

--- a/crt_cp.py
+++ b/crt_cp.py
@@ -16,6 +16,7 @@ CERT_FILES = [
 SRC_DIR_NAME = sys.argv[1]
 
 CERT_BASE_PATH = '/usr/syno/etc/certificate'
+PKG_CERT_BASE_PATH = '/usr/local/etc/certificate'
 
 ARCHIEV_PATH = CERT_BASE_PATH + '/_archive'
 INFO_FILE_PATH = ARCHIEV_PATH + '/INFO'
@@ -30,13 +31,14 @@ except:
 
 CP_FROM_DIR = ARCHIEV_PATH + '/' + SRC_DIR_NAME
 for service in services:
-    CP_TO_DIR = '%s/%s/%s' %(CERT_BASE_PATH, service['subscriber'], service['service'])
-    if not os.path.exists(CP_TO_DIR):
-        os.makedirs(CP_TO_DIR)
+    print 'Copy cert for %s' %(service['display_name'])
+    if service['isPkg']:
+        CP_TO_DIR = '%s/%s/%s' %(PKG_CERT_BASE_PATH, service['subscriber'], service['service'])
+    else:
+        CP_TO_DIR = '%s/%s/%s' % (CERT_BASE_PATH, service['subscriber'], service['service'])
     for f in CERT_FILES:
         src = CP_FROM_DIR + '/' + f 
         des = CP_TO_DIR + '/' + f
-        print src, des
         try:
             shutil.copy2(src, des)
         except:


### PR DESCRIPTION
- 应该可以解决 https://github.com/andyzhshg/syno-acme/issues/19 
- 目录不存在是因为套件的证书存放在另一个目录 https://github.com/andyzhshg/syno-acme/commit/576709e289806731cec02438ff7adb0dfbc90658
- 未解决套件服务自动重启