### PR TITLE
修复部分地区无法访问ACME_SH_ADDRESS

### DIFF
--- a/cert-up.sh
+++ b/cert-up.sh
@@ -29,7 +29,7 @@ installAcme () {
   mkdir -p ${TEMP_PATH}
   cd ${TEMP_PATH}
   echo 'begin downloading acme.sh tool...'
-  ACME_SH_ADDRESS=`curl -L https://raw.githubusercontent.com/andyzhshg/syno-acme/master/acme.sh.address`
+  ACME_SH_ADDRESS=`curl -L https://cdn.jsdelivr.net/gh/andyzhshg/syno-acme@master/acme.sh.address`
   SRC_TAR_NAME=acme.sh.tar.gz
   curl -L -o ${SRC_TAR_NAME} ${ACME_SH_ADDRESS}
   SRC_NAME=`tar -tzf ${SRC_TAR_NAME} | head -1 | cut -f1 -d"/"`


### PR DESCRIPTION
ACME_SH_ADDRESS原来采用的`https://raw.githubusercontent.com/andyzhshg/syno-acme/master/acme.sh.address`，在国内部分地区无法访问，采用jsdelivr进行CDN加速后可以解决问题。