### PR TITLE
Update cert-up.sh

### DIFF
--- a/cert-up.sh
+++ b/cert-up.sh
@@ -48,6 +48,7 @@ generateCrt () {
   source config
   echo 'begin updating default cert by acme.sh tool'
   source ${ACME_BIN_PATH}/acme.sh.env
+  ${ACME_BIN_PATH}/acme.sh --force --upgrade
   ${ACME_BIN_PATH}/acme.sh --force --log --issue --dns ${DNS} --dnssleep ${DNS_SLEEP} -d "${DOMAIN}" -d "*.${DOMAIN}"
   ${ACME_BIN_PATH}/acme.sh --force --installcert -d ${DOMAIN} -d *.${DOMAIN} \
     --certpath ${CRT_PATH}/cert.pem \


### PR DESCRIPTION
因为acme.sh目前的2.8.5版本中，dnsapi中的dns_dp.sh有问题会导致使用dnspod.cn的时候无法正常生成证书
该问题已经修正但没有正式release，详见：
https://github.com/acmesh-official/acme.sh/commit/20ba82025316e033d7cf9cc9db0f1abaaedf1b4e
除此之外dns_cf.sh（Cloudfalre的域名验证应该也是有问题的）

为了解决这个问题，比较便捷的办法是在issue证书之前把acme.sh升级一下，从release版本升级到最新版本
于是新增了一个51行： ${ACME_BIN_PATH}/acme.sh --force --upgrade