### PR TITLE
设置默认CA机构为Let's Encrypt

### DIFF
--- a/cert-up.sh
+++ b/cert-up.sh
@@ -37,6 +37,7 @@ installAcme () {
   echo 'begin installing acme.sh tool...'
   cd ${SRC_NAME}
   ./acme.sh --install --nocron --home ${ACME_BIN_PATH}
+  ./acme.sh --set-default-ca  --server  letsencrypt
   echo 'done installAcme'
   rm -rf ${TEMP_PATH}
   return 0


### PR DESCRIPTION
从 2021-08-01起，acme.sh 的默认证书颁发机构改为 ZeroSSL (https://github.com/acmesh-official/acme.sh/wiki/Change-default-CA-to-ZeroSSL)
但是ZeroSSL证书需要申请账号，否则原脚本会直接失败
因此在安装函数中额外设定默认CA为Let's Encrypt 而不使用最新的 ZeroSSL
