### PR TITLE
默认使用ZeroSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # syno-acme
-通过acme协议更新群晖HTTPS泛域名证书的自动脚本(DSM 6.x)
+通过acme协议更新群晖HTTPS泛域名证书的自动脚本(DSM 6.x)，DSM7 请切换dsm7分支
 
 ## 更新日志
 1、证书服务器调整为 ZeroSSL，不受API接口申请次数限制，请配置 config 文件；

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 通过acme协议更新群晖HTTPS泛域名证书的自动脚本(DSM 6.x)，DSM7 请切换dsm7分支
 
 ## 更新日志
-1、证书服务器调整为 ZeroSSL，不受API接口申请次数限制，请配置 config 文件；
+1、证书服务器默认为 ZeroSSL，如需使用 letsencrypt 请配置 config 文件；
 2、使用 ghproxy 文件加速下载服务，便于国内网络环境。
 3、更新 acme.sh 版本。
+4、支持 BARK 通知。
 
 使用方法参见: [http://www.up4dev.com/2018/05/29/synology-ssl-wildcard-cert-update/](http://www.up4dev.com/2018/05/29/synology-ssl-wildcard-cert-update/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # syno-acme
-通过acme协议更新群晖HTTPS泛域名证书的自动脚本
+通过acme协议更新群晖HTTPS泛域名证书的自动脚本(DSM 6.x)
+
+## 更新日志
+1、证书服务器调整为 ZeroSSL，不受API接口申请次数限制，请配置 config 文件；
+2、使用 ghproxy 文件加速下载服务，便于国内网络环境。
+3、更新 acme.sh 版本。
 
 使用方法参见: [http://www.up4dev.com/2018/05/29/synology-ssl-wildcard-cert-update/](http://www.up4dev.com/2018/05/29/synology-ssl-wildcard-cert-update/)

--- a/acme.sh.address
+++ b/acme.sh.address
@@ -1,1 +1,1 @@
-https://github.com/acmesh-official/acme.sh/archive/2.8.6.tar.gz
+https://ghproxy.com/https://github.com/acmesh-official/acme.sh/archive/refs/tags/3.0.4.tar.gz

--- a/cert-up.sh
+++ b/cert-up.sh
@@ -59,7 +59,12 @@ generateCrt () {
     revertCrt
     exit 1;
   fi
-  ${ACME_BIN_PATH}/acme.sh --force --log --issue --dns ${DNS} --dnssleep ${DNS_SLEEP} -d "${DOMAIN}" -d "*.${DOMAIN}"
+  if [ "${BARK_API_URL}" ];then
+    ${ACME_BIN_PATH}/acme.sh --force --log --issue --dns ${DNS} --dnssleep ${DNS_SLEEP} -d "${DOMAIN}" -d "*.${DOMAIN}" \
+  --set-notify --notify-hook bark
+  else
+    ${ACME_BIN_PATH}/acme.sh --force --log --issue --dns ${DNS} --dnssleep ${DNS_SLEEP} -d "${DOMAIN}" -d "*.${DOMAIN}"
+  fi
   ${ACME_BIN_PATH}/acme.sh --force --installcert -d ${DOMAIN} -d *.${DOMAIN} \
     --certpath ${CRT_PATH}/cert.pem \
     --key-file ${CRT_PATH}/privkey.pem \

--- a/cert-up.sh
+++ b/cert-up.sh
@@ -48,7 +48,17 @@ generateCrt () {
   source config
   echo 'begin updating default cert by acme.sh tool'
   source ${ACME_BIN_PATH}/acme.sh.env
-  ${ACME_BIN_PATH}/acme.sh --register-account -m ${ZeroSSL_Email} --server zerossl
+  if [[ ${SERVER_NAME} = "zerossl" ]]; then
+    ${ACME_BIN_PATH}/acme.sh --register-account -m ${ZeroSSL_Email} --server zerossl
+    ${ACME_BIN_PATH}/acme.sh --set-default-ca --server zerossl
+  elif [[ ${SERVER_NAME} = "letsencrypt" ]]; then
+    ${ACME_BIN_PATH}/acme.sh --set-default-ca --server letsencrypt
+  else
+    echo "[ERR] Please set SERVER_NAME in the config file !"
+    echo "begin revert"
+    revertCrt
+    exit 1;
+  fi
   ${ACME_BIN_PATH}/acme.sh --force --log --issue --dns ${DNS} --dnssleep ${DNS_SLEEP} -d "${DOMAIN}" -d "*.${DOMAIN}"
   ${ACME_BIN_PATH}/acme.sh --force --installcert -d ${DOMAIN} -d *.${DOMAIN} \
     --certpath ${CRT_PATH}/cert.pem \

--- a/cert-up.sh
+++ b/cert-up.sh
@@ -29,7 +29,7 @@ installAcme () {
   mkdir -p ${TEMP_PATH}
   cd ${TEMP_PATH}
   echo 'begin downloading acme.sh tool...'
-  ACME_SH_ADDRESS=`curl -L https://cdn.jsdelivr.net/gh/andyzhshg/syno-acme@master/acme.sh.address`
+  ACME_SH_ADDRESS=`cat ${BASE_ROOT}/acme.sh.address`
   SRC_TAR_NAME=acme.sh.tar.gz
   curl -L -o ${SRC_TAR_NAME} ${ACME_SH_ADDRESS}
   SRC_NAME=`tar -tzf ${SRC_TAR_NAME} | head -1 | cut -f1 -d"/"`
@@ -48,6 +48,7 @@ generateCrt () {
   source config
   echo 'begin updating default cert by acme.sh tool'
   source ${ACME_BIN_PATH}/acme.sh.env
+  ${ACME_BIN_PATH}/acme.sh --register-account -m ${ZeroSSL_Email} --server zerossl
   ${ACME_BIN_PATH}/acme.sh --force --log --issue --dns ${DNS} --dnssleep ${DNS_SLEEP} -d "${DOMAIN}" -d "*.${DOMAIN}"
   ${ACME_BIN_PATH}/acme.sh --force --installcert -d ${DOMAIN} -d *.${DOMAIN} \
     --certpath ${CRT_PATH}/cert.pem \
@@ -76,6 +77,7 @@ reloadWebService () {
   echo 'begin reloadWebService'
   echo 'reloading new cert...'
   /usr/syno/etc/rc.sysv/nginx.sh reload
+  synoservice --reload nginx
   echo 'relading Apache 2.2'
   stop pkg-apache22
   start pkg-apache22

--- a/config
+++ b/config
@@ -8,6 +8,9 @@ export DNS=dns_xxx
 # 某些域名服务商的API生效时间较大，需要将这个值加大(比如900)
 export DNS_SLEEP=120
 
+# 填写用于注册 ZeroSSL 账号的邮箱
+export ZeroSSL_Email=12345678@qq.com
+
 # 阿里云 DNS=dns_ali
 export Ali_Key="LTqIA87hOKdjevsf5"
 export Ali_Secret="0p5EYueFNq501xnCPzKNbx6K51qPH2"

--- a/config
+++ b/config
@@ -6,10 +6,10 @@ export DNS=dns_xxx
 
 # DNS API 生效等待时间 值(单位：秒)
 # 某些域名服务商的API生效时间较大，需要将这个值加大(比如900)
-export DNS_SLEEP=120
+export DNS_SLEEP=600
 
 # 填写用于注册 ZeroSSL 账号的邮箱
-export ZeroSSL_Email=12345678@qq.com
+export ZeroSSL_Email=email@example.com
 
 # 阿里云 DNS=dns_ali
 export Ali_Key="LTqIA87hOKdjevsf5"

--- a/config
+++ b/config
@@ -8,6 +8,9 @@ export DNS=dns_xxx
 # 某些域名服务商的API生效时间较大，需要将这个值加大(比如900)
 export DNS_SLEEP=600
 
+# 设置证书签发服务器 zerossl 或 letsencrypt 
+export SERVER_NAME="zerossl"
+
 # 填写用于注册 ZeroSSL 账号的邮箱
 export ZeroSSL_Email=email@example.com
 

--- a/config
+++ b/config
@@ -32,3 +32,8 @@ export AWS_SECRET_ACCESS_KEY="xxxxxxx"
 
 # Linode DNS=dns_linode
 export LINODE_API_KEY="xxxxxxxx"
+
+# 若需要开启bark通知，请取消#注释符，并替换 BARK_API_URL
+#export BARK_API_URL="https://api.day.app/XXXXXXXXXXXXXXXXXXXXXX"
+#export BARK_SOUND="newmail"
+#export BARK_GROUP=ACME


### PR DESCRIPTION
1、证书服务器调整为 ZeroSSL，不受API接口申请次数限制，需要在 config 文件配置邮箱；
2、使用 ghproxy 文件加速下载服务，便于国内网络环境。
3、更新 acme.sh 版本。